### PR TITLE
fix import for IHA1

### DIFF
--- a/Home Assignments/IHA1/IHA1.ipynb
+++ b/Home Assignments/IHA1/IHA1.ipynb
@@ -1031,7 +1031,7 @@
     "    Returns: # for test case purposes\n",
     "    A `numpy.ndarray` of predicted classes (integers [0-9]) with shape (11,)\n",
     "    \"\"\"\n",
-    "    data = np.load('./utils/test_data.npz_old')\n",
+    "    data = np.load('./utils/test_data.npz')\n",
     "    X, cls = data['X'], data['Y']\n",
     "    \n",
     "    cls_preds = None # TODO: make a predicted number for every image in X\n",


### PR DESCRIPTION
The `utils` folder needs `__init__.py` in order for Python 3 to traverse the directories properly to import files in subdirectories. Tested and functioning as intended on Python 3.5.2.