### PR TITLE
Correct commands are run on different OSes (including Windows)

### DIFF
--- a/Home Assignments/HA1/Create project structure.ipynb
+++ b/Home Assignments/HA1/Create project structure.ipynb
@@ -54,8 +54,13 @@
     "!unzip -q all.zip\n",
     "!unzip -q test1.zip\n",
     "!unzip -q train.zip\n",
-    "!mv test1 test\n",
-    "!rm test1.zip train.zip"
+    "\n",
+    "if os.name == \"nt\": # windows\n",
+    "    !move test1 test\n",
+    "    !del test1.zip train.zip\n",
+    "else:\n",
+    "    !mv test1 test\n",
+    "    !rm test1.zip train.zip"
    ]
   },
   {
@@ -258,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently, running the "Create project structure" notebook will not execute some commands for moving / cleaning up the data, if running Windows. This just checks which OS is being run, and chooses the proper substitute if on Windows (move for mv, del for rm).